### PR TITLE
Improvement docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # AGENTS.md
 
 ## Project Overview
-This is the personal website of Guillem Roca, hosted at [guillemroca.github.io](https://guillemroca.github.io). The project is a static site built with [Astro](https://astro.build) and deployed to GitHub Pages.
+This is the personal website of Guillem Roca, hosted at [guillem.dev](https://guillem.dev). The project is a static site built with [Astro](https://astro.build) and deployed to GitHub Pages.
 
 ## Tech Stack
 - **Framework**: Astro

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ This is the personal website of Guillem Roca, hosted at [guillemroca.github.io](
 ## Tech Stack
 - **Framework**: Astro
 - **Language**: TypeScript, HTML, CSS (standard)
+- **Asset Management**: `src/assets` for images (optimized), `public` for static files
 - **Deployment**: GitHub Pages via GitHub Actions
 - **Package Manager**: npm
 
@@ -14,7 +15,8 @@ This is the personal website of Guillem Roca, hosted at [guillemroca.github.io](
 - `src/pages/`: Contains the site's pages. Files here become routes.
 - `src/layouts/`: Shared layout components (e.g., `Layout.astro`).
 - `src/components/`: Reusable UI components.
-- `public/`: Static assets (fonts, images, `CNAME`, etc.) served at the root.
+- `src/assets/`: Images and other assets to be optimized by Astro.
+- `public/`: Static assets (fonts, `CNAME`, etc.) served at the root.
 - `.github/workflows/deploy.yml`: GitHub Actions workflow for automatic deployment.
 
 ## Development Commands

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,7 +15,7 @@ This is the personal website of Guillem Roca, hosted at [guillem.dev](https://gu
 - `src/pages/`: Contains the site's pages. Files here become routes.
 - `src/layouts/`: Shared layout components (e.g., `Layout.astro`).
 - `src/components/`: Reusable UI components.
-- `src/assets/`: Images and other assets to be optimized by Astro.
+- `src/assets/`: Images to be optimized by Astro.
 - `public/`: Static assets (fonts, `CNAME`, etc.) served at the root.
 - `.github/workflows/deploy.yml`: GitHub Actions workflow for automatic deployment.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Astro looks for `.astro` or `.md` files in the `src/pages/` directory. Each page
 
 There's nothing special about `src/components/`, but that's where we like to put any Astro/React/Vue/Svelte/Preact components.
 
-Any static assets, like images, can be placed in the `public/` directory.
+Images should be placed in `src/assets/` to leverage Astro's image optimization. Other static assets, like fonts or `CNAME`, can be placed in the `public/` directory.
 
 ## 🧞 Commands
 
@@ -37,7 +37,3 @@ All commands are run from the root of the project, from a terminal:
 | `npm run preview`         | Preview your build locally, before deploying     |
 | `npm run astro ...`       | Run CLI commands like `astro add`, `astro check` |
 | `npm run astro -- --help` | Get help using the Astro CLI                     |
-
-## 👀 Want to learn more?
-
-Feel free to check [our documentation](https://docs.astro.build) or jump into our [Discord server](https://astro.build/chat).


### PR DESCRIPTION
This pull request updates project documentation to clarify asset management and update the website's domain. The main focus is on specifying the recommended locations for images and other static assets, aligning with Astro's best practices, and updating references to the new domain.

**Documentation improvements:**

* Updated the website domain from `guillemroca.github.io` to `guillem.dev` in `AGENTS.md`.
* Clarified asset management in both `AGENTS.md` and `README.md`: images should be placed in `src/assets/` for Astro optimization, while other static assets (e.g., fonts, `CNAME`) remain in `public/`. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L17-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L26-R26)

**Other changes:**

* Removed the "Want to learn more?" section from `README.md` for a cleaner, more focused document.